### PR TITLE
Revert "changed from review"

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -129,23 +129,10 @@ function ExecuteDatabaseBuilds
 {
     if ($build.databases)
     {
-        $msbuild15 = "C:\Program Files (x86)\MSBuild\15.0\bin\msbuild.exe" 
-        $msbuild14 = "C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe" 
-        
-        if(Test-Path $msbuild15)
-        {
-                $msbuildPath = $msbuild15
-        }
-        else
-        {
-                $msbuildPath = $msbuild14
-        }
-
-
         $build.databases| ForEach {
           $output = $env:BUILD_ARTIFACTSTAGINGDIRECTORY + "\" + $_.name
            Write-Host "MSBuild Database to $output" -ForegroundColor Green
-           & $msbuildPath $_.path /p:OutputPath=$output
+           & "C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe" $_.path /p:OutputPath=$output
           if ($LASTEXITCODE -eq 1)
           {
               Write-Host "Error build database $_" -ForegroundColor Red
@@ -212,9 +199,16 @@ function ExecuteTests
       Write-Host $testProjects -ForegroundColor DarkYellow
       foreach ($file in $testProjects)
       {
-        $parent = Split-Path (Split-Path -Path $file.Fullname -Parent) -Leaf;
-        $testFile = "TEST-RESULTS-$parent.xml";
-        dotnet test $file -xml $testFile;
+        if ($file.FullName.EndsWith("csproj"))
+        {
+                dotnet test $file
+        }
+        else
+        {
+                $parent = Split-Path (Split-Path -Path $file.Fullname -Parent) -Leaf;
+                $testFile = "TEST-RESULTS-$parent.xml";
+                dotnet test $file -xml $testFile;
+        }
         $exitCode = [System.Math]::Max($lastExitCode, $exitCode);
       }
 


### PR DESCRIPTION
This reverts commit a1b38250ad712c1f75d3413948142eaa5db9432c.

i goofed and assume that msbuild 15 would come with a new exe and it does not so that check is not required.

Also we cant pass parameters to the xunit runner anymore as is discussed 

https://github.com/Microsoft/vstest/issues/786
and 
https://github.com/dotnet/cli/issues/3114

so we need to figure out a work around to get test results back.