### PR TITLE
Adding --logger option to output the test results as a TRX file. This…

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -237,7 +237,7 @@ function ExecuteTests
         {
             # This causes a conflict on Json.Net that I hope resolves itself
             # dotnet xunit -xml $testFile;
-            dotnet test;
+            dotnet test  --logger "trx;LogFileName=testResults.trx";
         }
         else
         {


### PR DESCRIPTION
… is a supported test out put by VSTS: https://docs.microsoft.com/en-us/vsts/build-release/tasks/test/publish-test-results?view=vsts

Example of how to use logger
https://stackoverflow.com/questions/39542533/xunit-dotnet-test-cli-to-output-to-nunit-xml-so-that-bamboo-can-read-the-results
